### PR TITLE
V2.1.1 - remove unused action parameter of outputFileNamePrefix

### DIFF
--- a/playground/local.ts
+++ b/playground/local.ts
@@ -6,9 +6,7 @@ const authKey = process.env.deepl_api_key as string;
 const translator = new deepl.Translator(authKey);
 const playgroundPath = "playground"
 const inputFilePath = path.join(playgroundPath, "nested.json");
-// note that if outputFileNamePattern is set, outputFileNamePrefix is ignored
 const outputFileNamePattern = path.join(playgroundPath, "locales/{language}/nested.json");
-const outputFileNamePrefix = path.join(playgroundPath, "translated_simple_");
 const startTagForNoTranslate = "<!-- keep -->";
 const endTagForNoTranslate = "<!-- /keep -->";
 
@@ -21,7 +19,6 @@ const targetLanguages = ["ja"] as deepl.TargetLanguageCode[];
 		translator,
 		inputFilePath,
 		outputFileNamePattern,
-		outputFileNamePrefix,
 		startTagForNoTranslate,
 		endTagForNoTranslate,
 		tempFilePath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,6 @@ const inputFilePath = path.join(
 	process.env.GITHUB_WORKSPACE as string,
 	process.env.input_file_path as string,
 );
-const outputFileNamePrefix = path.join(
-	process.env.GITHUB_WORKSPACE as string,
-	process.env.output_file_name_prefix as string,
-) || 'translated_';
 const outputFileNamePattern = path.join(
 	process.env.GITHUB_WORKSPACE as string,
 	process.env.output_file_name_pattern as string,
@@ -37,7 +33,6 @@ const fileExtensionsThatAllowForIgnoringBlocks = [".html", ".xml", ".md", ".txt"
 	await main({
 		translator,
 		inputFilePath,
-		outputFileNamePrefix,
 		outputFileNamePattern,
 		startTagForNoTranslate,
 		endTagForNoTranslate,

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,7 @@ interface HTMLlikeParams {
 export interface MainFunctionParams extends HTMLlikeParams {
 	translator: Translator;
 	inputFilePath: string;
-	outputFileNamePrefix: string;
-	outputFileNamePattern?: string;
+	outputFileNamePattern: string;
 	tempFilePath: string;
 	fileExtensionsThatAllowForIgnoringBlocks: string[];
 	targetLanguages: TargetLanguageCode[];
@@ -22,7 +21,6 @@ export async function main(params: MainFunctionParams) {
 	const {
 		translator,
 		inputFilePath,
-		outputFileNamePrefix,
 		outputFileNamePattern,
 		startTagForNoTranslate,
 		endTagForNoTranslate,
@@ -92,7 +90,7 @@ export async function main(params: MainFunctionParams) {
 				}
 				const resultText = removeKeepTagsFromString(translatedText);
 
-				const outputFileName = buildOutputFileName(targetLang, fileExtension, outputFileNamePrefix, outputFileNamePattern);
+				const outputFileName = buildOutputFileName(targetLang, outputFileNamePattern);
 				const outputFolderPath = path.dirname(outputFileName);
 				if (!fs.existsSync(outputFolderPath)) {
 					fs.mkdirSync(outputFolderPath, { recursive: true });
@@ -117,7 +115,7 @@ export async function main(params: MainFunctionParams) {
 
 				for (const targetLanguage of targetLanguages) {
 					const targetLang = targetLanguage as TargetLanguageCode;
-					const outputFileName = buildOutputFileName(targetLang, fileExtension, outputFileNamePrefix, outputFileNamePattern);
+					const outputFileName = buildOutputFileName(targetLang, outputFileNamePattern);
 					const resultJson = JSON.stringify(translatedResults[targetLang]);
 					const outputFolderPath = path.dirname(outputFileName);
 					if (!fs.existsSync(outputFolderPath)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,13 +115,9 @@ const translateRecursive = async (
 
 function buildOutputFileName(
 	targetLang: string,
-	fileExtension?: string,
-	outputFileNamePrefix?: string,
-	outputFileNamePattern?: string,
+	outputFileNamePattern: string,
 ) {
-	return outputFileNamePattern
-		? `${outputFileNamePattern.replace("{language}", targetLang)}`
-		: `${outputFileNamePrefix}${targetLang}${fileExtension}`;
+	return `${outputFileNamePattern.replace("{language}", targetLang)}`
 }
 
 export {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -28,7 +28,7 @@ describe("main - HTMLlike files", () => {
 
 	const fakeInputFileFolderPath = "test";
 	const fakeInputFilename = "inputFilePath.md";
-	const fakeOutputFileNamePrefix = `${fakeInputFileFolderPath}/`;
+	const fakeOutputFileNamePattern = `${fakeInputFileFolderPath}/`;
 	const fakeTempFilePath = "to_translate.txt";
 	const fakeReadFileResult = Buffer.from("Your mocked data here");
 
@@ -59,7 +59,7 @@ describe("main - HTMLlike files", () => {
 		const testParams: MainFunctionParams = {
 			translator: mockTranslator,
 			inputFilePath: `${fakeInputFileFolderPath}/${fakeInputFilename}`,
-			outputFileNamePrefix: fakeOutputFileNamePrefix,
+			outputFileNamePrefix: fakeOutputFileNamePattern,
 			tempFilePath: fakeTempFilePath,
 			fileExtensionsThatAllowForIgnoringBlocks: [".html", ".xml", ".md"],
 			targetLanguages: ["de"],
@@ -90,7 +90,7 @@ describe("main - JSON files", () => {
 
 	const fakeInputFileFolderPath = "test";
 	const fakeInputFilename = "inputFilePath.json";
-	const fakeOutputFileNamePrefix = `${fakeInputFileFolderPath}/`;
+	const fakeOutputFileNamePattern = `${fakeInputFileFolderPath}/{language}.json`;
 	const fakeTempFilePath = "to_translate.txt";
 	const testJSON = {
 		welcome: "Welcome, {name}!",
@@ -126,7 +126,7 @@ describe("main - JSON files", () => {
 		const testParams: MainFunctionParams = {
 			translator: mockTranslator,
 			inputFilePath: `${fakeInputFileFolderPath}/${fakeInputFilename}`,
-			outputFileNamePrefix: fakeOutputFileNamePrefix,
+			outputFileNamePattern: fakeOutputFileNamePattern,
 			tempFilePath: fakeTempFilePath,
 			fileExtensionsThatAllowForIgnoringBlocks: [".html", ".xml", ".md"],
 			targetLanguages: ["de"],


### PR DESCRIPTION
Going forward, `outputFileNamePrefix` is no longer used in favor of `outputFileNamePattern`